### PR TITLE
Trim empty lines from the top of the buffer

### DIFF
--- a/lua/trim/trimmer.lua
+++ b/lua/trim/trimmer.lua
@@ -9,7 +9,6 @@ local trimmer = {
     api.nvim_exec([[silent! %s/\%^\n\+//]], false)
     -- reference: https://unix.stackexchange.com/questions/12812/replacing-multiple-blank-lines-with-a-single-blank-line-in-vim-sed
     api.nvim_exec([[silent! %s/\(\n\n\)\n\+/\1/]], false)
-    
   end
 }
 


### PR DESCRIPTION
The plugin isn't currently removing empty lines from the top of the buffer.
I don't put references because I made this regex myself.
Have a good day!