### PR TITLE
Apply user defined config

### DIFF
--- a/lua/trim/init.lua
+++ b/lua/trim/init.lua
@@ -25,7 +25,7 @@ M.setup = function(cfg)
       pattern = '*',
       callback = function()
         if not has_value(cfg.disable, vim.bo.filetype) then
-          require 'trim.trimmer'.trim()
+          require 'trim.trimmer'.trim(cfg.patterns)
         end
       end,
       group = 'TrimNvim'

--- a/lua/trim/trimmer.lua
+++ b/lua/trim/trimmer.lua
@@ -1,12 +1,11 @@
 local vim = vim
 local api = vim.api
-local cfg = require 'trim.config'
 
 local trimmer = {}
 
-trimmer.trim = function()
+trimmer.trim = function(patterns)
     local save = vim.fn.winsaveview()
-    for _, v in pairs(cfg.patterns) do
+    for _, v in pairs(patterns) do
         api.nvim_exec(string.format("keepjumps keeppatterns silent! %s", v), false)
     end
     vim.fn.winrestview(save)


### PR DESCRIPTION
# 現象

- setup時に複数行のトリムを除外するよう定義したが、除外されない。

```lua
    require("trim").setup({
      patterns = {
        [[%s/\s\+$//e]],           -- remove unwanted spaces
        [[%s/\($\n\s*\)\+\%$//]],  -- trim last line
        [[%s/\%^\n\+//]],          -- trim first line
      },
    })
```

# 原因

- 必ずデフォルトのconfigが適用されているため。

# 対応

- ユーザが定義したコンフィグを適用するよう修正。