### PR TITLE
feat: separate highlight_bg and highlight_ctermbg

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ local default_config = {
   trim_first_line = true,
   highlight = false,
   highlight_bg = 'red',
+  highlight_ctermbg = 'red',
 }
 ```
 

--- a/lua/trim/config.lua
+++ b/lua/trim/config.lua
@@ -11,6 +11,7 @@ local default_config = {
   trim_first_line = true,
   highlight = false,
   highlight_bg = 'red',
+  highlight_ctermbg = 'red',
 }
 
 function M.setup(opts)
@@ -35,11 +36,7 @@ function M.setup(opts)
   end
 
   if M.config.highlight then
-    local highlight_cmd = string.format([[
-      highlight ExtraWhitespace ctermbg=%s guibg=%s
-    ]], M.config.highlight_bg, M.config.highlight_bg)
-
-    vim.api.nvim_exec(highlight_cmd, false)
+    vim.api.nvim_set_hl(0, "ExtraWhitespace", { bg = M.config.highlight_bg, ctermbg = M.config.highlight_ctermbg })
 
     vim.api.nvim_exec([[
       match ExtraWhitespace /\s\+$/


### PR DESCRIPTION
This enable users to use hex color for highlight bg.

Instead of specifying `highlight_bg = 'white'`, I prefer specifying `highlight_bg = '#ffffff'`.
But it's not possible because `ctermbg` doesn't support hex color.

This PR allows the user to do just that, I also simplify the code a little by using the API to create `highlight` instead of using `vim.api.nvim_exec()`.

Thanks before!
