### PR TITLE
Add trim of changed lines only

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ local default_config = {
   trim_trailing = true,
   trim_last_line = true,
   trim_first_line = true,
+  trim_changed_only = false, -- Trim only lines changed from last save
   highlight = false,
   highlight_bg = '#ff0000', -- or 'red'
   highlight_ctermbg = 'red',

--- a/doc/trim.nvim.txt
+++ b/doc/trim.nvim.txt
@@ -58,6 +58,7 @@ HOW TO SETUP                                *trim.nvim-trim.nvim-how-to-setup*
       trim_trailing = true,
       trim_last_line = true,
       trim_first_line = true,
+      trim_changed_only = false, -- Trim only lines changed from last save
       highlight = false,
       highlight_bg = '#ff0000', -- or 'red'
       highlight_ctermbg = 'red',

--- a/lua/trim/config.lua
+++ b/lua/trim/config.lua
@@ -9,6 +9,7 @@ local default_config = {
   trim_trailing = true,
   trim_last_line = true,
   trim_first_line = true,
+  trim_changed_only = false,
   highlight = false,
   highlight_bg = '#ff0000',
   highlight_ctermbg = 'red',
@@ -21,6 +22,13 @@ function M.setup(opts)
   if opts.disable and not opts.ft_blocklist then
     vim.notify('`disable` is deprecated, use `ft_blocklist` instead', vim.log.levels.WARN, { title = 'trim.nvim' })
     opts.ft_blocklist = opts.disable
+  end
+
+  if opts.trim_changed_only and vim.fn.executable('diff') == 0 then
+    vim.notify('`trim_changed_only` cannot function without a `diff` binary available in PATH. Disabling trimming.', { title = 'trim.nvim' })
+    opts.trim_first_line = false
+    opts.trim_last_line = false
+    opts.trim_trailing = false
   end
 
   M.config = vim.tbl_deep_extend('force', default_config, opts)

--- a/lua/trim/trimmer.lua
+++ b/lua/trim/trimmer.lua
@@ -3,11 +3,81 @@ local api = vim.api
 
 local trimmer = {}
 
+function trimmer.changed_blocks()
+  local filename = vim.api.nvim_buf_get_name(0)
+
+  if vim.fn.filereadable(filename) == 0 then
+    return {1, vim.fn.line('$')}
+  end
+
+  if vim.bo.modified then
+    local diff_bits = {
+      "diff",
+      "-a",
+      "--unchanged-group-format=",
+      "--old-group-format=",
+      "--new-group-format=%dF,%dL ",
+      "--changed-group-format=%dF,%dL ",
+      filename,
+      "-"
+    }
+
+    local format = vim.api.nvim_buf_get_option(0, 'fileformat')
+    local line_ending = line_endings[format]
+
+    local file_content = table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, true), line_ending) .. line_ending
+    local call_result = vim.system(diff_bits, {stdin = file_content, text = true}):wait()
+
+    local trimmed_output = vim.fn.trim(call_result.stdout)
+    local changes_list = vim.split(trimmed_output, ' ')
+    local result = vim.tbl_map(function(val)
+      return vim.split(val, ',')
+    end, changes_list)
+
+    return result
+  end
+
+  return {}
+end
+
+local format_line_endings = {
+  unix = "\n",
+  dos = "\r\n",
+  mac = "\r",
+}
+
 function trimmer.trim()
   local config = require('trim.config').get()
   local save = vim.fn.winsaveview()
-  for _, v in ipairs(config.patterns) do
-    api.nvim_exec(string.format('keepjumps keeppatterns silent! %s', v), false)
+  if config.trim_changed_only then
+    local line_trailing_pattern = [[s/\s\+$//e]]
+    local changed_blocks = trimmer.changed_blocks()
+
+    -- Trim ends of all changed lines
+    local num_changed_lines = 0
+    for _, range in ipairs(changed_blocks) do
+      local command = string.format('keepjumps keeppatterns silent! %s,%s%s', range[1], range[2], line_trailing_pattern)
+      api.nvim_exec2(command)
+      num_changed_lines = num_changed_lines + 1
+    end
+
+    -- NOTE: order is important, do trailing first, then leading, otherwise the
+    -- line ranges might not be accurate anymore
+    local line_count = vim.api.nvim_buf_line_count(0)
+    if config.trim_last_line and num_changed_lines > 0 and changed_blocks[num_changed_lines][2] == line_count then
+      -- Last changed range extends to EOF -> We can trim trailing lines
+      api.nvim_exec2([[keepjumps keeppatterns silent! %s/\($\n\s*\)\+\%$//]])
+    end
+
+    if config.trim_first_line and num_changed_lines > 0 and changed_blocks[1][1] == 1 then
+      -- First changed range starts at first line -> We can trim leading lines
+      api.nvim_exec2([[keepjumps keeppatterns silent! %s/\%^\n\+//]])
+    end
+  else
+    -- Trim globally
+    for _, v in ipairs(config.patterns) do
+      api.nvim_exec2(string.format('keepjumps keeppatterns silent! %s', v), false)
+    end
   end
   vim.fn.winrestview(save)
 end

--- a/lua/trim/trimmer.lua
+++ b/lua/trim/trimmer.lua
@@ -13,7 +13,7 @@ function trimmer.changed_blocks()
   local filename = vim.api.nvim_buf_get_name(0)
 
   if vim.fn.filereadable(filename) == 0 then
-    return {1, vim.fn.line('$')}
+    return {{1, vim.fn.line('$')}}
   end
 
   if vim.bo.modified then

--- a/lua/trim/trimmer.lua
+++ b/lua/trim/trimmer.lua
@@ -3,6 +3,12 @@ local api = vim.api
 
 local trimmer = {}
 
+local format_line_endings = {
+  unix = "\n",
+  dos = "\r\n",
+  mac = "\r",
+}
+
 function trimmer.changed_blocks()
   local filename = vim.api.nvim_buf_get_name(0)
 
@@ -23,28 +29,22 @@ function trimmer.changed_blocks()
     }
 
     local format = vim.api.nvim_buf_get_option(0, 'fileformat')
-    local line_ending = line_endings[format]
+    local line_ending = format_line_endings[format]
 
     local file_content = table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, true), line_ending) .. line_ending
     local call_result = vim.system(diff_bits, {stdin = file_content, text = true}):wait()
 
     local trimmed_output = vim.fn.trim(call_result.stdout)
     local changes_list = vim.split(trimmed_output, ' ')
-    local result = vim.tbl_map(function(val)
-      return vim.split(val, ',')
-    end, changes_list)
+    local split_fn = function(val)
+      return vim.split(val, ",")
+    end
 
-    return result
+    return vim.tbl_map(split_fn, changes_list)
   end
 
   return {}
 end
-
-local format_line_endings = {
-  unix = "\n",
-  dos = "\r\n",
-  mac = "\r",
-}
 
 function trimmer.trim()
   local config = require('trim.config').get()
@@ -54,29 +54,29 @@ function trimmer.trim()
     local changed_blocks = trimmer.changed_blocks()
 
     -- Trim ends of all changed lines
-    local num_changed_lines = 0
+    local num_changed_blocks = 0
     for _, range in ipairs(changed_blocks) do
       local command = string.format('keepjumps keeppatterns silent! %s,%s%s', range[1], range[2], line_trailing_pattern)
-      api.nvim_exec2(command)
-      num_changed_lines = num_changed_lines + 1
+      api.nvim_exec2(command, {output = false})
+      num_changed_blocks = num_changed_blocks + 1
     end
 
     -- NOTE: order is important, do trailing first, then leading, otherwise the
     -- line ranges might not be accurate anymore
     local line_count = vim.api.nvim_buf_line_count(0)
-    if config.trim_last_line and num_changed_lines > 0 and changed_blocks[num_changed_lines][2] == line_count then
+    if config.trim_last_line and num_changed_blocks > 0 and tonumber(changed_blocks[num_changed_blocks][2]) == line_count then
       -- Last changed range extends to EOF -> We can trim trailing lines
-      api.nvim_exec2([[keepjumps keeppatterns silent! %s/\($\n\s*\)\+\%$//]])
+      api.nvim_exec2([[keepjumps keeppatterns silent! %s/\($\n\s*\)\+\%$//]], {output = false})
     end
 
-    if config.trim_first_line and num_changed_lines > 0 and changed_blocks[1][1] == 1 then
+    if config.trim_first_line and num_changed_blocks > 0 and tonumber(changed_blocks[1][1]) == 1 then
       -- First changed range starts at first line -> We can trim leading lines
-      api.nvim_exec2([[keepjumps keeppatterns silent! %s/\%^\n\+//]])
+      api.nvim_exec2([[keepjumps keeppatterns silent! %s/\%^\n\+//]], {output = false})
     end
   else
     -- Trim globally
     for _, v in ipairs(config.patterns) do
-      api.nvim_exec2(string.format('keepjumps keeppatterns silent! %s', v), false)
+      api.nvim_exec2(string.format('keepjumps keeppatterns silent! %s', v), {output = false})
     end
   end
   vim.fn.winrestview(save)


### PR DESCRIPTION
Closes #22.

Adds the config option `trim_changed_only` (default `false`).

I think this is a relatively neat fix that even retains leading lines and trailing lines trimming for only changed lines. I have to admit I didn't do much more than translate the general solution approach that `vim-better-whitespace` uses [here](https://github.com/ntpeters/vim-better-whitespace/blob/029f35c783f1b504f9be086b9ea757a36059c846/plugin/better-whitespace.vim#L262) to figure out the changed blocks, except that this version even ensures the line breaks conform to `fileformat` (otherwise diff may falsely report the entire file is changed).

For this to work, `diff` must be on the `PATH`, and if it isn't, you get a complaint and trimming deactivates entirely.

Note that in principle the regexes used for trimming should still be updated to work with all the other line endings for true compatibility. It would amount to replacing `\n` with `\(\r\n\|\r\|\n\)` in the trailing and leading lines trimming regexes.

Although I've been dogfooding this for a little bit, this is the first time I'm messing with Lua, so please give it some close scrutiny. It's quite possible there are some functionality or perf corner cases with the functions I'm using that I'm not aware of.