### PR TITLE
feat: add notifications configuration and separate is_enabled check

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ local default_config = {
   highlight = false,
   highlight_bg = '#ff0000', -- or 'red'
   highlight_ctermbg = 'red',
+  notifications = true,
 }
 ```
 

--- a/lua/trim/config.lua
+++ b/lua/trim/config.lua
@@ -12,6 +12,7 @@ local default_config = {
   highlight = false,
   highlight_bg = '#ff0000',
   highlight_ctermbg = 'red',
+  notifications = true,
 }
 
 function M.setup(opts)
@@ -48,7 +49,7 @@ function M.setup(opts)
           -- Apply highlighting for trailing whitespace
           vim.api.nvim_set_hl(0, 'ExtraWhitespace', {
             bg = M.config.highlight_bg,
-            ctermbg = M.config.highlight_ctermbg
+            ctermbg = M.config.highlight_ctermbg,
           })
           vim.api.nvim_exec('match ExtraWhitespace /\\s\\+$/', false)
         else

--- a/lua/trim/trimmer.lua
+++ b/lua/trim/trimmer.lua
@@ -34,22 +34,31 @@ function trimmer.enable(is_configured)
       end
     end,
   })
-  if not is_configured then
+  if config.notifications and not is_configured then
     vim.notify('TrimNvim enabled', vim.log.levels.INFO, { title = 'trim.nvim' })
   end
 end
 
 function trimmer.disable()
   pcall(vim.api.nvim_del_augroup_by_name, 'TrimNvim')
-  vim.notify('TrimNvim disabled', vim.log.levels.INFO, { title = 'trim.nvim' })
+  if require('trim.config').get().notifications then
+    vim.notify('TrimNvim disabled', vim.log.levels.INFO, { title = 'trim.nvim' })
+  end
 end
 
-function trimmer.toggle()
+function trimmer.is_enabled()
   local status = pcall(vim.api.nvim_get_autocmds, {
     group = 'TrimNvim',
     event = 'BufWritePre',
   })
   if not status then
+    return false
+  end
+  return true
+end
+
+function trimmer.toggle()
+  if not trimmer.is_enabled() then
     trimmer.enable(false)
   else
     trimmer.disable()

--- a/tests/core/config_spec.lua
+++ b/tests/core/config_spec.lua
@@ -32,6 +32,10 @@ describe('default config', function()
     assert.are.equal(actual.patterns[2], [[%s/\%^\n\+//]])
     assert.are.equal(actual.patterns[3], [[%s/\($\n\s*\)\+\%$//]])
   end)
+
+  it('has notifications enabled', function()
+    assert.is_true(actual.notifications)
+  end)
 end)
 
 describe('config', function()


### PR DESCRIPTION
This was helpful for me in doing some configuration/automation so thought I'd share upstream.

There are 2 main changes:

- Add a `notifications` config option to enable/disable notifications
- Add a separate `is_enabled` function for checking auto-trim status
