### PR TITLE
Improve highlight

### DIFF
--- a/lua/trim/config.lua
+++ b/lua/trim/config.lua
@@ -37,10 +37,7 @@ function M.setup(opts)
   end
 
   if M.config.highlight then
-    local highlighter = require 'trim.highlighter'
-    vim.api.nvim_create_autocmd({ 'InsertLeave', 'TextChanged', 'TextChangedI' }, {
-      callback = highlighter.highlight,
-    })
+    require("trim.highlighter").setup()
   end
 end
 

--- a/lua/trim/highlighter.lua
+++ b/lua/trim/highlighter.lua
@@ -13,22 +13,30 @@ local has_value = function(tbl, val)
   return false
 end
 
-function highlighter.highlight()
-  vim.api.nvim_exec2('match none', { output = false })
-  if has_value(config.ft_blocklist, vim.bo.filetype) then
-    return
-  end
-  if not highlighter.is_pending then
-    highlighter.is_pending = true
-    vim.defer_fn(function()
-      vim.api.nvim_set_hl(0, 'ExtraWhitespace', {
-        bg = config.highlight_bg,
-        ctermbg = config.highlight_ctermbg,
-      })
-      vim.api.nvim_exec2('match ExtraWhitespace /\\s\\+$/', { output = false })
-      highlighter.is_pending = false
-    end, 1000)
-  end
+function highlighter.setup()
+  vim.api.nvim_set_hl(0, 'ExtraWhitespace', {
+    bg = config.highlight_bg,
+    ctermbg = config.highlight_ctermbg,
+  })
+
+  local augroup = vim.api.nvim_create_augroup('TrimHighlight', { clear = true })
+  vim.api.nvim_create_autocmd('FileType', {
+    group = augroup,
+    pattern = '*',
+    callback = function()
+      if vim.bo.buftype == '' and not has_value(config.ft_blocklist, vim.bo.filetype) then
+        -- Trailing whitespaces
+        vim.fn.matchadd('ExtraWhitespace', '\\s\\+$')
+        -- no highlight for whitespaces before cursor position
+        vim.fn.matchadd('Conceal', '\\s\\+\\%#')
+
+        -- Trailing empty lines
+        vim.fn.matchadd('ExtraWhitespace', '^\\_s*\\%$')
+        -- no highlight for lines before cursor line
+        vim.fn.matchadd('Conceal', '^\\_s*\\%#')
+      end
+    end,
+  })
 end
 
 return highlighter


### PR DESCRIPTION
Why not defer_fn?

Highlight by `defer_fn 1000` feels laggy and the text editing is not pleasant.

Why not TextChanged autocmd?

TextChanged is triggered on every char input, which means a lot unnecessary function calls to `highlighter.highlight`. FileType autocmd should be fine enough to do highlights.

What's new in PR?

No highlight for trailing whitespaces/empty lines before cursor position, which is an alternate solution to issue [#26](https://github.com/cappyzawa/trim.nvim/issues/26)