### PR TITLE
fix whitespace highlighting

### DIFF
--- a/lua/trim/highlighter.lua
+++ b/lua/trim/highlighter.lua
@@ -56,7 +56,7 @@ function highlighter.setup()
   })
 
   local augroup = vim.api.nvim_create_augroup('TrimHighlight', { clear = true })
-  vim.api.nvim_create_autocmd({ 'BufEnter', 'WinEnter' }, {
+  vim.api.nvim_create_autocmd({ 'BufEnter', 'WinEnter', 'TermEnter' }, {
     group = augroup,
     callback = function()
       if vim.bo.buftype == '' and not has_value(config.ft_blocklist, vim.bo.filetype) then
@@ -71,7 +71,7 @@ function highlighter.setup()
 
   -- After cursor left window, the matches related to cursor would not work,
   -- so clear them on BufLeave/WinLeave
-  vim.api.nvim_create_autocmd({ 'BufLeave', 'WinLeave' }, {
+  vim.api.nvim_create_autocmd({ 'BufLeave', 'WinLeave', 'TermLeave' }, {
     group = augroup,
     callback = function()
       delete_cursor_matches()

--- a/lua/trim/highlighter.lua
+++ b/lua/trim/highlighter.lua
@@ -13,6 +13,42 @@ local has_value = function(tbl, val)
   return false
 end
 
+local function add_whitespace_matches()
+  if vim.w.trim_whitespace_match_ids == nil then
+    vim.w.trim_whitespace_match_ids = {
+      -- Trailing whitespaces
+      vim.fn.matchadd('ExtraWhitespace', '\\s\\+$'),
+      -- Trailing empty lines
+      vim.fn.matchadd('ExtraWhitespace', '^\\_s*\\%$'),
+    }
+  end
+end
+
+local function add_cursor_matches()
+  if vim.w.trim_cursor_match_ids == nil then
+    vim.w.trim_cursor_match_ids = {
+      -- no highlight for whitespaces before cursor position
+      vim.fn.matchadd('Conceal', '\\s\\+\\%#'),
+      -- no highlight for lines before cursor line
+      vim.fn.matchadd('Conceal', '^\\_s*\\%#'),
+    }
+  end
+end
+
+local function delete_whitespace_matches()
+  for _, matchid in ipairs(vim.w.trim_whitespace_match_ids or {}) do
+    vim.fn.matchdelete(matchid)
+  end
+  vim.w.trim_whitespace_match_ids = nil
+end
+
+local function delete_cursor_matches()
+  for _, matchid in ipairs(vim.w.trim_cursor_match_ids or {}) do
+    vim.fn.matchdelete(matchid)
+  end
+  vim.w.trim_cursor_match_ids = nil
+end
+
 function highlighter.setup()
   vim.api.nvim_set_hl(0, 'ExtraWhitespace', {
     bg = config.highlight_bg,
@@ -20,21 +56,25 @@ function highlighter.setup()
   })
 
   local augroup = vim.api.nvim_create_augroup('TrimHighlight', { clear = true })
-  vim.api.nvim_create_autocmd('FileType', {
+  vim.api.nvim_create_autocmd({ 'BufEnter', 'WinEnter' }, {
     group = augroup,
-    pattern = '*',
     callback = function()
       if vim.bo.buftype == '' and not has_value(config.ft_blocklist, vim.bo.filetype) then
-        -- Trailing whitespaces
-        vim.fn.matchadd('ExtraWhitespace', '\\s\\+$')
-        -- no highlight for whitespaces before cursor position
-        vim.fn.matchadd('Conceal', '\\s\\+\\%#')
-
-        -- Trailing empty lines
-        vim.fn.matchadd('ExtraWhitespace', '^\\_s*\\%$')
-        -- no highlight for lines before cursor line
-        vim.fn.matchadd('Conceal', '^\\_s*\\%#')
+        add_whitespace_matches()
+        add_cursor_matches()
+      else
+        delete_whitespace_matches()
+        delete_cursor_matches()
       end
+    end,
+  })
+
+  -- After cursor left window, the matches related to cursor would not work,
+  -- so clear them on BufLeave/WinLeave
+  vim.api.nvim_create_autocmd({ 'BufLeave', 'WinLeave' }, {
+    group = augroup,
+    callback = function()
+      delete_cursor_matches()
     end,
   })
 end


### PR DESCRIPTION
Before this fix, when cursor jump to another window, some char before cursor in previous window would disappear, which probably is caused by Conceal matches.

This fix removes cursor-related highlight matches when current window is not focused.

This also fix a problem that `matches` are repeatedly added to current window after buffer is reloaded. This can be checked by vim cmd `echo getmatches()`.