### PR TITLE
feat: add trim_current_line option to exclude cursor line

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ local default_config = {
   trim_trailing = true,
   trim_last_line = true,
   trim_first_line = true,
+  trim_current_line = true,
   highlight = false,
   highlight_bg = '#ff0000', -- or 'red'
   highlight_ctermbg = 'red',
@@ -62,6 +63,10 @@ require('trim').setup({
 
   -- if you want to disable trim on write by default
   trim_on_write = false,
+
+  -- if you want to exclude the current line from trimming
+  -- useful when used with auto-save plugins to avoid deleting auto-indentation
+  trim_current_line = false,
 
   -- highlight trailing spaces
   highlight = true

--- a/lua/trim/config.lua
+++ b/lua/trim/config.lua
@@ -9,6 +9,7 @@ local default_config = {
   trim_trailing = true,
   trim_last_line = true,
   trim_first_line = true,
+  trim_current_line = true,
   highlight = false,
   highlight_bg = '#ff0000',
   highlight_ctermbg = 'red',
@@ -26,7 +27,14 @@ function M.setup(opts)
 
   M.config = vim.tbl_deep_extend('force', default_config, opts)
 
-  if M.config.trim_trailing then
+  -- preserve user-specified patterns, reset if not specified
+  local user_patterns = opts.patterns or {}
+  M.config.patterns = {}
+  for _, p in ipairs(user_patterns) do
+    table.insert(M.config.patterns, p)
+  end
+
+  if M.config.trim_trailing and M.config.trim_current_line then
     table.insert(M.config.patterns, [[%s/\s\+$//e]])
   end
   if M.config.trim_first_line then

--- a/lua/trim/trimmer.lua
+++ b/lua/trim/trimmer.lua
@@ -12,7 +12,24 @@ function trimmer.trim(range, line1, line2)
     local cmd = string.format('keepjumps keeppatterns silent! %d,%ds/\\s\\+$//e', line1, line2)
     api.nvim_exec2(cmd, {})
   else
-    -- no range: apply all patterns to the entire buffer
+    -- trim_trailing with cursor line exclusion
+    if config.trim_trailing and not config.trim_current_line then
+      local lnum = vim.api.nvim_win_get_cursor(0)[1]
+      local last = vim.api.nvim_buf_line_count(0)
+
+      -- trim lines above cursor
+      if lnum > 1 then
+        local cmd = string.format('keepjumps keeppatterns silent! 1,%ds/\\s\\+$//e', lnum - 1)
+        api.nvim_exec2(cmd, {})
+      end
+      -- trim lines below cursor
+      if lnum < last then
+        local cmd = string.format('keepjumps keeppatterns silent! %d,$s/\\s\\+$//e', lnum + 1)
+        api.nvim_exec2(cmd, {})
+      end
+    end
+
+    -- apply other patterns (trim_first_line, trim_last_line, custom patterns)
     for _, v in ipairs(config.patterns) do
       api.nvim_exec2(string.format('keepjumps keeppatterns silent! %s', v), {})
     end

--- a/tests/core/trimmer_spec.lua
+++ b/tests/core/trimmer_spec.lua
@@ -64,4 +64,50 @@ describe('trimmer.trim', function()
     assert.are.equal('', lines[4]) -- last empty line preserved
     vim.cmd 'bdelete!'
   end)
+
+  it('excludes cursor line when trim_current_line is false', function()
+    config.setup({ trim_current_line = false })
+
+    vim.cmd 'new'
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+      'line1   ',
+      'line2  ',
+      'line3   ',
+      'line4  ',
+    })
+
+    -- set cursor to line 2
+    vim.api.nvim_win_set_cursor(0, { 2, 0 })
+
+    trimmer.trim()
+
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    assert.are.equal('line1', lines[1]) -- trimmed
+    assert.are.equal('line2  ', lines[2]) -- cursor line: untouched
+    assert.are.equal('line3', lines[3]) -- trimmed
+    assert.are.equal('line4', lines[4]) -- trimmed
+    vim.cmd 'bdelete!'
+  end)
+
+  it('trims all lines when trim_current_line is true (default)', function()
+    config.setup({ trim_current_line = true })
+
+    vim.cmd 'new'
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+      'line1   ',
+      'line2  ',
+      'line3   ',
+    })
+
+    -- set cursor to line 2
+    vim.api.nvim_win_set_cursor(0, { 2, 0 })
+
+    trimmer.trim()
+
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    assert.are.equal('line1', lines[1]) -- trimmed
+    assert.are.equal('line2', lines[2]) -- cursor line: also trimmed
+    assert.are.equal('line3', lines[3]) -- trimmed
+    vim.cmd 'bdelete!'
+  end)
 end)


### PR DESCRIPTION
## Summary
- Add new option `trim_current_line` (default: `true`)
- When set to `false`, the cursor line is excluded from trimming
- Useful when using auto-save plugins to preserve auto-indentation

## Usage
```lua
require('trim').setup({
  trim_current_line = false,
})
```

Resolves #24